### PR TITLE
Include Homebrew in PATH for build tool to find go

### DIFF
--- a/Sources/WireGuardApp/Config/Config.xcconfig
+++ b/Sources/WireGuardApp/Config/Config.xcconfig
@@ -1,2 +1,4 @@
 #include "Version.xcconfig"
 #include "Developer.xcconfig"
+
+PATH = ${PATH}:/opt/homebrew/bin


### PR DESCRIPTION
Fixes this opaque error when building `WireGuardGoBridge`, due to Xcode not finding the go binary in PATH:

```
Command ExternalBuildToolExecution failed with a nonzero exit code
```