### PR TITLE
Map missing iPhone Simulator platform

### DIFF
--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -20,6 +20,7 @@ GOARCH_arm64 := arm64
 GOARCH_x86_64 := amd64
 GOOS_macosx := darwin
 GOOS_iphoneos := ios
+GOOS_iphonesimulator := ios
 
 build: $(DESTDIR)/libwg-go.a
 version-header: $(DESTDIR)/wireguard-go-version.h


### PR DESCRIPTION
Fixes WireGuardKitGo target failing due to missing symbols, when compiled for iPhone Simulator.

AFAIC it was an issue on arm64 (M1).