### PR TITLE
Mention OnDemand in MOBILECONFIG.md

### DIFF
--- a/MOBILECONFIG.md
+++ b/MOBILECONFIG.md
@@ -86,6 +86,10 @@ keys:
 
     - `AuthenticationMethod` (string): Should be `Password`
 
+    - `OnDemandEnabled` (integer): Optional, set to `1` to enable on-demand activation.
+
+    - `OnDemandRules` (array): Optional, an array with on-demand rules. See [this gist](https://gist.github.com/deg0nz/bec056213aef57d84b05b21bb046a16c) for an example.
+
 Here's an example WireGuard configuration payload dictionary:
 
 ```xml

--- a/MOBILECONFIG.md
+++ b/MOBILECONFIG.md
@@ -88,7 +88,7 @@ keys:
 
     - `OnDemandEnabled` (integer): Optional, set to `1` to enable on-demand activation.
 
-    - `OnDemandRules` (array): Optional, an array with on-demand rules. See [this gist](https://gist.github.com/deg0nz/bec056213aef57d84b05b21bb046a16c) for an example.
+    - `OnDemandRules` (array): Optional, an array with on-demand rules. See the [Configuration Profile Reference, page 95](https://developer.apple.com/business/documentation/Configuration-Profile-Reference.pdf) for more information, or [this gist](https://gist.github.com/deg0nz/bec056213aef57d84b05b21bb046a16c) for an example.
 
 Here's an example WireGuard configuration payload dictionary:
 


### PR DESCRIPTION
This adds a brief explainer of the `OnDemandEnabled` and `OnDemandRules` keys that can be set in a MobileConfig.

For now, I added a link to https://gist.github.com/deg0nz/bec056213aef57d84b05b21bb046a16c, which has an example for `OnDemandRules`.  Since it can become quite complex, I'm not sure if we should include it in this document, or maybe split it out in a separate file.