### PR TITLE
Allows build to run on iOS Simulator for Apple Silicon

### DIFF
--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -21,6 +21,11 @@ GOARCH_x86_64 := amd64
 GOOS_macosx := darwin
 GOOS_iphoneos := ios
 
+UNAME := $(shell uname -m)
+ifeq ($(UNAME), $(GOARCH_arm64))
+	GOOS_iphonesimulator := ios
+endif
+
 build: $(DESTDIR)/libwg-go.a
 version-header: $(DESTDIR)/wireguard-go-version.h
 


### PR DESCRIPTION
Allows wireguard-go to be built for iOS simulator which runs on Apple Silicon.