### PR TITLE
Adding -fembed-bitcode flag to enable bitcode in XCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Sources/WireGuardApp/Config/Developer.xcconfig
 
 # Vim
 .*.sw*
+
+# VSCode
+.vscode/

--- a/Sources/WireGuardKitGo/Makefile
+++ b/Sources/WireGuardKitGo/Makefile
@@ -35,7 +35,7 @@ $(GOROOT)/.prepared:
 
 define libwg-go-a
 $(BUILDDIR)/libwg-go-$(1).a: export CGO_ENABLED := 1
-$(BUILDDIR)/libwg-go-$(1).a: export CGO_CFLAGS := $(CFLAGS_PREFIX) $(ARCH)
+$(BUILDDIR)/libwg-go-$(1).a: export CGO_CFLAGS := -fembed-bitcode $(CFLAGS_PREFIX) $(ARCH)
 $(BUILDDIR)/libwg-go-$(1).a: export CGO_LDFLAGS := $(CFLAGS_PREFIX) $(ARCH)
 $(BUILDDIR)/libwg-go-$(1).a: export GOOS := $(GOOS_$(PLATFORM_NAME))
 $(BUILDDIR)/libwg-go-$(1).a: export GOARCH := $(GOARCH_$(1))


### PR DESCRIPTION
"Currently libwg-go.a doesn't support bitcode in the Xcode project. It
crashes with the following message:

libwg-go.a does not contain bitcode. You must rebuild it with bitcode
enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from
the vendor, or disable bitcode for this target. for architecture arm64

Disabling Bitcode for the whole project is very bad for dSYMs and
Crashlytics reporting, though" 

Full discussion is [here](https://www.mail-archive.com/wireguard@lists.zx2c4.com/msg07049.html)