### PR TITLE
Close the device when an error occurred

### DIFF
--- a/Sources/WireGuardKitGo/api-apple.go
+++ b/Sources/WireGuardKitGo/api-apple.go
@@ -112,6 +112,7 @@ func wgTurnOn(settings *C.char, tunFd int32) int32 {
 	err = dev.IpcSet(C.GoString(settings))
 	if err != nil {
 		logger.Errorf("Unable to set IPC settings: %v", err)
+		dev.Close();
 		unix.Close(dupTunFd)
 		return -1
 	}
@@ -126,6 +127,7 @@ func wgTurnOn(settings *C.char, tunFd int32) int32 {
 		}
 	}
 	if i == math.MaxInt32 {
+		dev.Close();
 		unix.Close(dupTunFd)
 		return -1
 	}


### PR DESCRIPTION
I'm not familiar with this code, but it seems that the device needs to be closed in case of errors.