### PR TITLE
Handle dock icon click to open Tunnel Manager (`applicationShouldHandleReopen`)

### DIFF
--- a/Sources/WireGuardApp/UI/macOS/AppDelegate.swift
+++ b/Sources/WireGuardApp/UI/macOS/AppDelegate.swift
@@ -151,6 +151,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return false
     }
 
+    func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+        self?.showManageTunnelsWindow(completion: nil)
+        return true
+    }
+
     private func setDockIconAndMainMenuVisibility(isVisible: Bool, completion: (() -> Void)? = nil) {
         let currentActivationPolicy = NSApp.activationPolicy()
         let newActivationPolicy: NSApplication.ActivationPolicy = isVisible ? .regular : .accessory


### PR DESCRIPTION
One thing that bugs me about the WireGuard macOS app is that clicking on its Dock icon does not open the Tunnel Manager window. This is non macOS-like, and limits the ability to show that window programatically via shell scripts, AppleScript, JXA, Alfred etc.

My poor-man's kludge to automate this is to literally quit the app and re-open it, like this (JXA):
```javascript
function run(argv) {
  var WG = new Application("WireGuard");
  WG.quit();
  WG.activate();
  return;
}
```

...but that's embarrassingly inefficient. I believe after looking at the code that it's because there's no `applicationShouldHandleReopen()` func handler.

So this is not a full working PR, just a bit of starter code I was hoping to get refined into a working fix. I do believe the fix is small and fairly easy to implement.

References:
- https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428638-applicationshouldhandlereopen
- https://developer.apple.com/forums/thread/706772?answerId=715063022#715063022

