### PR TITLE
Bug: Fix incorrect IP address allocation size

### DIFF
--- a/Sources/WireGuardKit/IPAddress+AddrInfo.swift
+++ b/Sources/WireGuardKit/IPAddress+AddrInfo.swift
@@ -8,7 +8,7 @@ extension IPv4Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: MemoryLayout<sockaddr_in>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin_addr, count: MemoryLayout<in_addr>.size)
         }
 
@@ -20,7 +20,7 @@ extension IPv6Address {
     init?(addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET6 else { return nil }
 
-        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: MemoryLayout<sockaddr_in6>.size) { ptr -> Data in
+        let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr -> Data in
             return Data(bytes: &ptr.pointee.sin6_addr, count: MemoryLayout<in6_addr>.size)
         }
 


### PR DESCRIPTION
Documentation for `withMemoryRebound(to:capacity:_:)` is available below: https://developer.apple.com/documentation/swift/unsafepointer/withmemoryrebound(to:capacity:_:)

According to it, the `capacity` parameter is specified as "the number of instances of T in the re-bound region," and not the total size of the rebound struct. This can lead to crashes in the extension with the following error:

`Fatal error: self must be a properly aligned pointer for types Pointee and T`

Since the subsequent line in the code only reads `sizeof(in_addr)` or `sizeof(in6_addr)` anyway, change the `capacity` parameter to just be a count of 1.