### PR TITLE
Bump minimum versions of the app to iOS 14 and macos 11.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "WireGuardKit",
     platforms: [
-        .macOS(.v10_14),
-        .iOS(.v12)
+        .macOS(.v11_1),
+        .iOS(.v14)
     ],
     products: [
         .library(name: "WireGuardKit", targets: ["WireGuardKit"])


### PR DESCRIPTION
There is probably barely anyone that uses iOS 12 anymore and so I propose it should be dropped for support. macOS gets a tiny min version bump here