### PR TITLE
Only show max 3 allowed ips in status menu

### DIFF
--- a/Sources/WireGuardApp/UI/macOS/StatusMenu.swift
+++ b/Sources/WireGuardApp/UI/macOS/StatusMenu.swift
@@ -107,7 +107,7 @@ class StatusMenu: NSMenu {
             networksMenuItem.title = ""
             networksMenuItem.isHidden = true
         } else {
-            let allowedIPs = tunnel.tunnelConfiguration?.peers.flatMap { $0.allowedIPs }.map { $0.stringRepresentation }.joined(separator: ", ") ?? ""
+            let allowedIPs = tunnel.tunnelConfiguration?.peers.flatMap { $0.allowedIPs }.map { $0.stringRepresentation }.prefix(3).joined(separator: ", ") ?? ""
             if !allowedIPs.isEmpty {
                 networksMenuItem.title = tr(format: "macMenuNetworks (%@)", allowedIPs)
             } else {


### PR DESCRIPTION
When a lot of ips are added to the allowed ip list the popups grows horizontally.
![image](https://user-images.githubusercontent.com/1675955/220757040-804041b2-c637-4e08-9dfc-1b275cd7c8b9.png)

This PR limits the popup to show the first 3 ips only.