### PR TITLE
App: fix build error caused by SwiftPM version difference

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
My App's Network Extension causes the following error, depends on public remote SwiftPM package.

```
Invalid manifest

/(path_to)/TemporaryFile.hzdchM.swift:9:17: error: 'v12' is unavailable
.macOS(.v12),
^~~
PackageDescription.SupportedPlatform:18:27: note: 'v12' was introduced in PackageDescription 5.5
public static let v12: PackageDescription.SupportedPlatform.MacOSVersion
^
/(path_to)/TemporaryFile.hzdchM.swift:10:15: error: 'v15' is unavailable
.iOS(.v15)
^~~
PackageDescription.SupportedPlatform:65:27: note: 'v15' was introduced in PackageDescription 5.5
public static let v15: PackageDescription.SupportedPlatform.IOSVersion
^ in https://git.zx2c4.com/wireguard-apple
```

As error message says, `MacOSVersion.v12`[^1] and `IOSVersion.v15`[^2] are available in PackageDescription 5.5 and above, but `Package.swift` still specifies SwiftPM version 5.3.
So, we must bump the `swift-tools-version` as well.

[^1]: https://developer.apple.com/documentation/packagedescription/supportedplatform/macosversion/v12
[^2]: https://developer.apple.com/documentation/packagedescription/supportedplatform/iosversion/v15