### PR TITLE
Edit button not showing right and bottom borders on TunnelDetailView on MacOS

### DIFF
--- a/Sources/WireGuardApp/UI/macOS/ViewController/TunnelDetailTableViewController.swift
+++ b/Sources/WireGuardApp/UI/macOS/ViewController/TunnelDetailTableViewController.swift
@@ -151,8 +151,8 @@ class TunnelDetailTableViewController: NSViewController {
             bottomControlsContainer.heightAnchor.constraint(equalToConstant: 32),
             scrollView.bottomAnchor.constraint(equalTo: bottomControlsContainer.topAnchor),
             bottomControlsContainer.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            editButton.trailingAnchor.constraint(equalTo: bottomControlsContainer.trailingAnchor),
-            bottomControlsContainer.bottomAnchor.constraint(equalTo: editButton.bottomAnchor, constant: 0)
+            editButton.trailingAnchor.constraint(equalTo: bottomControlsContainer.trailingAnchor, constant: -1),
+            bottomControlsContainer.bottomAnchor.constraint(equalTo: editButton.bottomAnchor, constant: 1)
         ])
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
The "Edit" button on TunnelDetailView did not show right and bottom borders.

**Before:**
<img width="61" alt="image" src="https://github.com/WireGuard/wireguard-apple/assets/29739749/7da952c8-29b4-4725-babe-fbe882a19243">

**After:**
<img width="61" alt="image" src="https://github.com/WireGuard/wireguard-apple/assets/29739749/6d001e21-b165-43bf-aede-7d62ad224cb6">