### PR TITLE
Problem with building Wireguard SDK (Missing required modules: 'WireGuardKitC', 'WireGuardKitGo')

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
I am using the `1.0.15-26` version & Xcode 15 (same as Xcode 14.3), tried diff versions, and usually the same result:

When I try to `import WireGuardKit` I receive this message:

<img width="396" alt="image" src="https://github.com/WireGuard/wireguard-apple/assets/35520974/5a32f9e3-cac1-41e1-be48-829a8d39cc04">

<img width="858" alt="image" src="https://github.com/WireGuard/wireguard-apple/assets/35520974/7715d3cd-0363-48e0-b7fd-534553995643">

I spent a few days on this, reintegrating Wireguard SDK using instructions & other experiences.
Also, I have a user-defined `PATH` variable at Build Settings:

<img width="619" alt="image" src="https://github.com/WireGuard/wireguard-apple/assets/35520974/020f9090-c708-475d-b7b1-0a157d2a5fc2">
