### PR TITLE
WireGuardKitC: fix build with Xcode 16b1

### DIFF
--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
+#include <sys/types.h>
+
 #include "key.h"
 #include "x25519.h"
 


### PR DESCRIPTION
This commit fixes build errors of the WireGuardKitC target appearing with Xcode 16b1. Errors are:

> Declaration of 'u_int32_t'/'u_char'/'u_int16_t'  must be imported from module
  'DarwinFoundation.unsigned_types.*' before it is required"