### PR TITLE
Refactor private key generation with status check

### DIFF
--- a/Sources/WireGuardKitC/x25519.c
+++ b/Sources/WireGuardKitC/x25519.c
@@ -172,7 +172,8 @@ void curve25519_derive_public_key(uint8_t public_key[32], const uint8_t private_
 
 void curve25519_generate_private_key(uint8_t private_key[32])
 {
-    assert(CCRandomGenerateBytes(private_key, 32) == kCCSuccess);
+    CCRNGStatus status = CCRandomGenerateBytes(private_key, 32);
+    assert(status == kCCSuccess);
     private_key[31] = (private_key[31] & 127) | 64;
     private_key[0] &= 248;
 }


### PR DESCRIPTION
The assert is ignored in release builds when NDEBUG is set; the private key will not always be the same. Check assert.h.   Only wrap the condition-checking code inside assert.