### PR TITLE
Update Package.swift to swift tools version 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
+#include <stdint.h>
+
 #include "key.h"
 #include "x25519.h"
 
 /* From <sys/kern_control.h> */
 #define CTLIOCGINFO 0xc0644e03UL
 struct ctl_info {
-    u_int32_t   ctl_id;
+    uint32_t    ctl_id;
     char        ctl_name[96];
 };
 struct sockaddr_ctl {
-    u_char      sc_len;
-    u_char      sc_family;
-    u_int16_t   ss_sysaddr;
-    u_int32_t   sc_id;
-    u_int32_t   sc_unit;
-    u_int32_t   sc_reserved[5];
+    uint8_t     sc_len;
+    uint8_t     sc_family;
+    uint16_t    ss_sysaddr;
+    uint32_t    sc_id;
+    uint32_t    sc_unit;
+    uint32_t    sc_reserved[5];
 };


### PR DESCRIPTION
### What It Does
- Updated the Swift tools version at the top of `Package.swift` from 5.3 to 5.9 to require a newer Swift toolchain.

### How I Tested
- Made the fork and tried adding the package in Xcode and saw that it resolved

### Notes
- I needed to do this so I could use this package in Xcode 26

### Screenshots
| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e384b3e0-239c-482c-9f68-0c1447ffa7c7" width="300" /> | <img src="https://github.com/user-attachments/assets/b99693a4-dac4-49f1-957a-1bb3d29dd61a" width="300" /> |
